### PR TITLE
fix: fix padding quick search button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,7 +34,7 @@ const Home = async () => {
         <div className="mt-6 flex gap-3 overflow-x-scroll [&::-webkit-scrollbar]:hidden">
           {quickSearchOptions.map((option) => (
             <Button
-              className="gap-2"
+              className="shrink-0 gap-2"
               variant="secondary"
               key={option.title}
               asChild


### PR DESCRIPTION
### Problema a ser resolvido:
Devido ao uso do flex na div que envolve os botão de busca rápida os padding desse botões não estavam sendo mantido, deixando o visual diferente do proposto no protótipo.

![image](https://github.com/user-attachments/assets/fa2d6053-0645-4943-895d-d8d512562135)

### Solução:
Corrige o padding do botão de pesquisa rápida com a classe shrink-0.

![image](https://github.com/user-attachments/assets/0fb5e8ae-86fd-4d7b-9ea2-eb771237049c)
